### PR TITLE
Reference my own docker image instead

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
     required: false
 runs:
   using: docker
-  image: docker://zendesk/resharper-action
+  image: docker://szymonkazmierczak/resharper-action:1.0
   args:
     - sh
     - -c


### PR DESCRIPTION
Faster to republish images... might even go further and just use the dockerfile directly if this doesn't work 🤷 